### PR TITLE
🪳 Skip staging deploy for dependabot-updates PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,7 +128,7 @@ jobs:
 
   deploy-staging:
     needs: build-and-push
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' && github.base_ref != 'dependabot-updates'
     runs-on: ubuntu-latest
     concurrency:
       group: deploy-staging


### PR DESCRIPTION
## Summary

- Adds `&& github.base_ref != 'dependabot-updates'` to the `deploy-staging` job condition
- Dependabot PRs targeting `dependabot-updates` don't have access to `FIRTH_SSH_KEY`, causing staging deploys to always fail for routine dependency updates

## Test plan

- [ ] Verify a Dependabot PR targeting `dependabot-updates` runs tests but skips `deploy-staging`
- [ ] Verify a normal feature PR still triggers `deploy-staging` as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)